### PR TITLE
Change the grep to be more specific

### DIFF
--- a/templates/updateRoute53.sh.j2
+++ b/templates/updateRoute53.sh.j2
@@ -8,7 +8,7 @@ if [ -z "$IP" ]; then
 fi
 echo "IP to update: $IP"
 
-HOSTED_ZONE_ID=$( aws route53 list-hosted-zones-by-name | grep -B 1 -e "{{ aws_route53_zone }}" | sed 's/.*hostedzone\/\([A-Za-z0-9]*\)\".*/\1/' | head -n 1 )
+HOSTED_ZONE_ID=$( aws route53 list-hosted-zones-by-name | grep -B 1 -e "Name\": \"{{ aws_route53_zone }}" | sed 's/.*hostedzone\/\([A-Za-z0-9]*\)\".*/\1/' | head -n 1 )
 echo "Hosted zone being modified: $HOSTED_ZONE_ID"
 
 INPUT_JSON=$( cat /tmp/update-route53-A.json | sed "s/127\.0\.0\.1/$IP/" )


### PR DESCRIPTION
because otherwise it is possible tha a wrong zone will be shown per grep

For example:
Find input: system.example.com

Available hosted zones:
- staging-system.example.com
- system.example.com

Without this change it is possible that `staging-system.example.com` will be selected instead of the correct one